### PR TITLE
header购物车点击不同商品，商品详情没有跳转bug修复

### DIFF
--- a/src/page/Goods/goodsDetails.vue
+++ b/src/page/Goods/goodsDetails.vue
@@ -85,8 +85,8 @@
     },
     methods: {
       ...mapMutations(['ADD_CART', 'ADD_ANIMATION', 'SHOW_CART']),
-      _productDet (productId) {
-        productDet({params: {productId}}).then(res => {
+      _productDet () {
+        productDet({params: {productId: this.$route.query.productId}}).then(res => {
           let result = res.result
           this.product = result
           this.productMsg = result.detail || ''
@@ -138,9 +138,11 @@
     components: {
       YShelf, BuyNum, YButton
     },
+    watch: {
+      '$route': '_productDet'
+    },
     created () {
-      let id = this.$route.query.productId
-      this._productDet(id)
+      this._productDet()
       this.userId = getStore('userId')
     }
   }


### PR DESCRIPTION
当header购物车中点击不同商品的时候，虽然路由发生了变化，productId发生了变化，但是没有监听，也没有触发_productDet方法，所以详情页面没有改变。
还有一个问题就是购物车有多个商品的时候如
A 2（数量）
B 3（数量）
当我删除A商品，结果就变为B 2，是因为buynum组件中的num传进来的是个值，不是对象。这个改起来东西比较多，你这边自己改一下哈。